### PR TITLE
Allowed ArgType conversion from String in pipeline CLI and Parser

### DIFF
--- a/dtran/argtype.py
+++ b/dtran/argtype.py
@@ -2,8 +2,8 @@
 # -*- coding: utf-8 -*-
 from typing import *
 from pathlib import Path
-from collections import OrderedDict
 from datetime import datetime
+from dateutil import parser
 
 
 class ArgType(object):
@@ -16,11 +16,13 @@ class ArgType(object):
     Boolean: 'ArgType' = None
     DateTime: 'ArgType' = None
 
-    def __init__(self, id: str, optional: bool = False, val: Any = None, validate: Callable[[Any], bool] = lambda val: True):
+    def __init__(self, id: str, optional: bool = False, val: Any = None,
+                 validate: Callable[[Any], bool] = lambda val: True, from_str: Callable[[str], Any] = lambda val: val):
         self.id = id
         self.val = val
         self.optional = optional
         self.validate = validate
+        self.from_str = from_str
 
     def __eq__(self, other):
         if other is None or not isinstance(other, ArgType):
@@ -33,51 +35,28 @@ class ArgType(object):
             return self
         return ArgType(self.id, optional, val)
 
+    def is_valid(self, val: Any):
+        try:
+            return self.validate(val)
+        except (TypeError, ValueError):
+            return False
 
-def validate_file_path(value):
-    try:
-        str(Path(value))
-        return True
-    except TypeError:
-        raise TypeError('Invalid Argument type. Expected FilePath')
-
-
-def validate_ordered_dict(value):
-    try:
-        OrderedDict(value)
-        return True
-    except ValueError:
-        raise TypeError('Invalid Argument type. Expected OrderedDict')
+    def type_cast(self, val: str):
+        if not isinstance(val, str):
+            raise NotImplementedError('type_casting is only supported from string type currently')
+        try:
+            return self.from_str(val)
+        except (TypeError, ValueError, KeyError):
+            raise ValueError(f"could not convert string to {self.id}")
 
 
-def validate_string(value):
-    if isinstance(value, str):
-        return True
-    raise TypeError('Invalid Argument type. Expected String')
-
-
-def validate_number(value):
-    if isinstance(value, int) or isinstance(value, float):
-        return True
-    raise TypeError('Invalid Argument type. Expected Number')
-
-
-def validate_boolean(value):
-    if isinstance(value, bool):
-        return True
-    raise TypeError('Invalid Argument type. Expected Boolean')
-
-
-def validate_datetime(value):
-    if isinstance(value, datetime):
-        return True
-    raise TypeError('Invalid Argument type. Expected DateTime')
-
-
-ArgType.FilePath = ArgType("file_path", validate=validate_file_path)
-ArgType.OrderedDict = ArgType("ordered_dict", validate=validate_ordered_dict)
+ArgType.FilePath = ArgType("file_path", validate=lambda val: Path(val).parent.exists(), from_str=lambda val: str(Path(val)))
+ArgType.OrderedDict = ArgType("ordered_dict", validate=lambda val: isinstance(val, dict))
 ArgType.NDimArray = ArgType("ndim_array")
-ArgType.String = ArgType("string", validate=validate_string)
-ArgType.Number = ArgType("number", validate=validate_number)
-ArgType.Boolean = ArgType("boolean", validate=validate_boolean)
-ArgType.DateTime = ArgType("datetime", validate=validate_datetime)
+ArgType.String = ArgType("string", validate=lambda val: isinstance(val, str))
+ArgType.Number = ArgType("number", validate=lambda val: isinstance(val, int) or isinstance(val, float),
+                         from_str=lambda val: ('.' in val and float(val)) or int(val))
+ArgType.Boolean = ArgType("boolean", validate=lambda val: isinstance(val, bool),
+                          from_str=lambda val: {'True': True, 'true': True, 'False': False, 'false': False}[val])
+ArgType.DateTime = ArgType("datetime", validate=lambda val: isinstance(val, datetime),
+                           from_str=lambda val: parser.parse(val))

--- a/dtran/config_parser.py
+++ b/dtran/config_parser.py
@@ -6,7 +6,8 @@ from typing import Union, Tuple, Dict
 from marshmallow import Schema, fields, validate, ValidationError, post_load
 from collections import OrderedDict, defaultdict
 from importlib import import_module
-
+from dtran.wireio import WiredIOArg
+from dtran.ifunc import IFunc
 from dtran import Pipeline
 
 wired_pattern = re.compile(r'^\$\.\w+\.\w+$')
@@ -27,6 +28,10 @@ class AdapterSchema(Schema):
 
 
 class PipelineSchema(Schema):
+    def __init__(self, cli_inputs, **kwargs):
+        super().__init__(**kwargs)
+        self.cli_inputs = cli_inputs
+
     version = fields.Str(required=True)
     description = fields.Str()
     adapters = OrderedDictField(required=True, validate=validate.Length(min=1),
@@ -39,44 +44,78 @@ class PipelineSchema(Schema):
     @post_load
     def construct_pipeline(self, data, **kwargs):
         adapter_count = defaultdict(int)
+        # map from custom function name to adapter class and order eg. {'MyCutomName1': (<class 'funcs.readers.read_func.ReadFunc'>, 1)}
         mappings = {}
         for name, adapter in data['adapters'].items():
-            mod, *cls = adapter['adapter'].rsplit('.')
+            # separating module path and adapter class
+            mod, *cls = adapter['adapter'].rsplit('.', 1)
             try:
                 mod = import_module(mod)
                 cls = getattr(mod, cls[0])
-            except (ModuleNotFoundError, IndexError, AttributeError):
-                raise ValidationError(f"Invalid adapter {adapter['adapter']} for {name}")
+                assert issubclass(cls, IFunc)
+            except (ModuleNotFoundError, AttributeError, ValueError) as e:
+                raise ValidationError([str(e), f"could not import adapter {adapter['adapter']} for {name}"])
+            except IndexError:
+                raise ValidationError(f"missing adapter class in {adapter['adapter']} for {name}")
+            except AssertionError:
+                raise ValidationError(f"invalid adapter class {adapter['adapter']} for {name}")
             adapter_count[adapter['adapter']] += 1
             mappings[name] = (cls, adapter_count[adapter['adapter']])
+
+        # validating cli_inputs
+        for name, input in self.cli_inputs:
+            if name not in mappings:
+                raise ValidationError(['cli_inputs exception', f"invalid adapter name {name}. not found in config file"])
+            if input not in mappings[name][0].inputs:
+                raise ValidationError(['cli_inputs exception', f"invalid input {input} in {data['adapters'][name]['adapter']} for {name}"])
+            # cli_inputs has higher priority and overwrites config_file data
+            if 'inputs' not in data['adapters'][name]:
+                data['adapters'][name]['inputs'] = OrderedDict()
+            data['adapters'][name]['inputs'][input] = self.cli_inputs[(name, input)]
+
         inputs = {}
         wired = []
         func_classes = []
+        # processing data and populating inputs
         for name, adapter in data['adapters'].items():
             func_classes.append(mappings[name][0])
             if 'inputs' not in adapter:
                 continue
             for input, value in adapter['inputs'].items():
+                # validating input
+                if input not in mappings[name][0].inputs:
+                    raise ValidationError(f"invalid input {input} in {data['adapters'][name]['adapter']} for {name}")
+                # processing wiring inputs
                 if isinstance(value, str) and wired_pattern.match(value):
                     adapter_name, output = value.split('.')[1:]
+                    # validating wired input
                     if adapter_name not in mappings:
-                        raise ValidationError(f"Invalid adapter name {adapter_name} in input {input} for {name}")
+                        raise ValidationError(f"invalid adapter name {adapter_name} in input {input} for {name}")
+                    elif output not in mappings[adapter_name][0].outputs:
+                        raise ValidationError(f"invalid output {output} of {adapter_name} in input {input} for {name}")
                     wired.append(
                         getattr(getattr(mappings[adapter_name][0].O, f"_{mappings[adapter_name][1]}"), output)
                         == getattr(getattr(mappings[name][0].I, f"_{mappings[name][1]}"), input)
                     )
+                # processing other inputs
                 else:
-                    inputs[f"{mappings[name][0].id}__{mappings[name][1]}__{input}"] = value
-        for name in mappings:
-            mappings[name] = f"{mappings[name][0].id}__{mappings[name][1]}__"
-        return Pipeline(func_classes, wired), inputs, mappings
+                    argtype = mappings[name][0].inputs[input]
+                    # type casting input from string to required argtype
+                    if isinstance(value, str):
+                        try:
+                            value = argtype.type_cast(value)
+                        except (NotImplementedError, ValueError) as e:
+                            raise ValidationError([str(e), f"type casting failed in input {input} for {name}"])
+                    inputs[WiredIOArg.get_arg_name(mappings[name][0].id, mappings[name][1], input)] = value
+
+        return Pipeline(func_classes, wired), inputs
 
 
 class ConfigParser:
-    def __init__(self):
-        self.schema = PipelineSchema()
+    def __init__(self, cli_inputs: Dict = None):
+        self.schema = PipelineSchema(cli_inputs or {})
 
-    def parse(self, path: Union[Path, str]) -> Tuple[Pipeline, Dict, Dict]:
+    def parse(self, path: Union[Path, str]) -> Tuple[Pipeline, Dict]:
         path = str(path)
         if path.endswith('.json'):
             return self._parse_from_json(path)
@@ -84,11 +123,11 @@ class ConfigParser:
             return self._parse_from_yaml(path)
         raise Exception(f"Unsupported file format for{path}. Only supports json or yaml file")
 
-    def _parse_from_yaml(self, path: Union[Path, str]) -> Tuple[Pipeline, Dict, Dict]:
+    def _parse_from_yaml(self, path: Union[Path, str]) -> Tuple[Pipeline, Dict]:
         yaml = YAML()
         with open(str(path), 'r') as file:
             return self.schema.load(yaml.load(file))
 
-    def _parse_from_json(self, path: Union[Path, str]) -> Tuple[Pipeline, Dict, Dict]:
+    def _parse_from_json(self, path: Union[Path, str]) -> Tuple[Pipeline, Dict]:
         with open(str(path), 'r') as file:
             return self.schema.load(ujson.load(file))

--- a/dtran/pipeline.py
+++ b/dtran/pipeline.py
@@ -63,7 +63,8 @@ class Pipeline(object):
                 if gname in self.wired:
                     continue
                 argtype = func_cls.inputs[argname]
-                self.schema[gname] = fields.Raw(required=not argtype.optional, validate=argtype.validate)
+                self.schema[gname] = fields.Raw(required=not argtype.optional, validate=argtype.is_valid,
+                                                error_messages={'validator_failed': f"Invalid Argument type. Expected {argtype.id}"})
         self.schema = Schema.from_dict(self.schema)
 
     def exec(self, inputs: dict) -> dict:


### PR DESCRIPTION
- Add is_valid method to validate argtype
- Add type_cast in Argtype to convert from string to required argtype
- Enable cli_inputs to be passed to pipeline configuration parser

See [task](https://github.com/mintproject/MINT-Transformation/projects/1#card-28423795)