### PR TITLE
Creating new ArgType DataSet replacing NDimArray and Graph

### DIFF
--- a/dtran/argtype.py
+++ b/dtran/argtype.py
@@ -6,23 +6,29 @@ from datetime import datetime
 from dateutil import parser
 
 
+def dataset(val: Any, preference: str = None, input_ref: str = None) -> 'ArgType':
+    assert preference is None or preference == 'graph' or preference == 'array', 'preference only accepts values "graph" or "array"'
+    return ArgType("dataset", val=val, preference=preference, input_ref=input_ref)
+
+
 class ArgType(object):
     FilePath: 'ArgType' = None
-    Graph: Callable[[Any], 'ArgType'] = lambda val: ArgType("graph", val=val)
+    DataSet: Callable[[Any, str, str], 'ArgType'] = dataset
     OrderedDict: 'ArgType' = None
-    NDimArray: 'ArgType' = None
     String: 'ArgType' = None
     Number: 'ArgType' = None
     Boolean: 'ArgType' = None
     DateTime: 'ArgType' = None
 
     def __init__(self, id: str, optional: bool = False, val: Any = None,
-                 validate: Callable[[Any], bool] = lambda val: True, from_str: Callable[[str], Any] = lambda val: val):
+                 validate: Callable[[Any], bool] = lambda val: True, from_str: Callable[[str], Any] = lambda val: val,
+                 **kwargs):
         self.id = id
         self.val = val
         self.optional = optional
         self.validate = validate
         self.from_str = from_str
+        vars(self).update(kwargs)
 
     def __eq__(self, other):
         if other is None or not isinstance(other, ArgType):
@@ -52,7 +58,6 @@ class ArgType(object):
 
 ArgType.FilePath = ArgType("file_path", validate=lambda val: Path(val).parent.exists(), from_str=lambda val: str(Path(val)))
 ArgType.OrderedDict = ArgType("ordered_dict", validate=lambda val: isinstance(val, dict))
-ArgType.NDimArray = ArgType("ndim_array")
 ArgType.String = ArgType("string", validate=lambda val: isinstance(val, str))
 ArgType.Number = ArgType("number", validate=lambda val: isinstance(val, int) or isinstance(val, float),
                          from_str=lambda val: ('.' in val and float(val)) or int(val))

--- a/dtran/ifunc.py
+++ b/dtran/ifunc.py
@@ -62,3 +62,9 @@ class IFunc(metaclass=IFuncIO):
                 raise NotImplementedError(f"Doesn't handle {and_expr} yet")
 
         return eval(f"lambda n: " + " and ".join(conditions))
+
+    def set_preferences(self, preferences: Dict[str, str]) -> None:
+        self.preferences = preferences
+
+    def get_preference(self, output: str) -> str:
+        return self.preferences[output]


### PR DESCRIPTION
created DataSet ArgType representing the common API for array and graph. Through this dataset, adapters can specify their input preferences between 'array' and 'graph' backends, and the pipeline chooses the best one. There are two properties as input to DataSet ArgType:

- preference - This only applies to input datasets and is ignored for output datasets. It accepts values "array" or "graph" representing the  2 backends of the API, or None if no preference. 

- input_ref - This only applies to output datasets and is ignored for input datasets. It accepts a string value which can refer to any dataset input to the same adapter. This is used to indicate which input dataset the adapter has modified and sending as output. If the output dataset is new and not modified from any input, then the value can be None (default)