### PR TITLE
update pipeline to detect deadlock

### DIFF
--- a/dtran/argtype.py
+++ b/dtran/argtype.py
@@ -76,7 +76,7 @@ ArgType.FilePath = ArgType("file_path", validate=lambda val: Path(val).parent.ex
 ArgType.OrderedDict = ArgType("ordered_dict", validate=lambda val: isinstance(val, dict))
 ArgType.ListString = ArgType("list_string", validate=lambda val: isinstance(val, list) and all(isinstance(x, str) for x in val))
 ArgType.String = ArgType("string", validate=lambda val: isinstance(val, str))
-ArgType.Number = ArgType("number", validate=lambda val: isinstance(val, int) or isinstance(val, float),
+ArgType.Number = ArgType("number", validate=lambda val: isinstance(val, (int, float)),
                          from_str=lambda val: ('.' in val and float(val)) or int(val))
 ArgType.Boolean = ArgType("boolean", validate=lambda val: isinstance(val, bool),
                           from_str=lambda val: {'True': True, 'true': True, 'False': False, 'false': False}[val])

--- a/dtran/config_parser.py
+++ b/dtran/config_parser.py
@@ -68,7 +68,7 @@ class PipelineSchema(Schema):
         else:
             inputs = enumerate(val)
         for input, value in inputs:
-            if isinstance(value, str) or isinstance(value, dict) or isinstance(value, list):
+            if isinstance(value, (str, dict, list)):
                 val[input] = PipelineSchema.process_input(value, data)
         return val
 
@@ -121,7 +121,7 @@ class PipelineSchema(Schema):
                 if input not in mappings[name][0].inputs:
                     raise ValidationError(f"invalid input {input} in {data['adapters'][name]['adapter']} for {name}")
                 # processing for root-level pipeline inputs
-                if isinstance(value, str) or isinstance(value, dict) or isinstance(value, list):
+                if isinstance(value, (str, dict, list)):
                     try:
                         value = PipelineSchema.process_input(value, data)
                     except ValidationError as e:

--- a/dtran/config_parser.py
+++ b/dtran/config_parser.py
@@ -44,7 +44,8 @@ class PipelineSchema(Schema):
     description = fields.Str()
     inputs = OrderedDictField(validate=validate.Length(min=1),
                               keys=fields.Str(validate=validate.Regexp(keys_pattern)),
-                              values=fields.Nested(InputSchema()))
+                              values=fields.Function(deserialize=lambda value: InputSchema().load(value)
+                              if isinstance(value, dict) else value))
     adapters = OrderedDictField(required=True, validate=validate.Length(min=1),
                                 keys=fields.Str(validate=validate.Regexp(keys_pattern)),
                                 values=fields.Nested(AdapterSchema()))
@@ -61,7 +62,7 @@ class PipelineSchema(Schema):
             input_name = val.split('.')[1:][0]
             if ('inputs' not in data) or (input_name not in data['inputs']):
                 raise ValidationError(f"invalid pipeline input {input_name}")
-            return data['inputs'][input_name]['value']
+            return data['inputs'][input_name]['value'] if isinstance(data['inputs'][input_name], dict) else data['inputs'][input_name]
         if isinstance(val, dict):
             inputs = val.items()
         else:

--- a/environment.yml
+++ b/environment.yml
@@ -4,13 +4,13 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python=3.7
+  - python=3.8
   - pip
   - gdal=3.0.4
   - scipy
   - pydap=3.2.2
   - numpy
-  - fiona=1.8
+  - shapely=1.7
   - dask=2.11.0
   - pip:
       - drepr>=2.9.2

--- a/examples/aggregation/average_daily_all_variables.yml
+++ b/examples/aggregation/average_daily_all_variables.yml
@@ -1,9 +1,8 @@
 version: "1.0"
 description: Data transformation to generate daily average data from original GLDAS data sources
 inputs:
-  gldas_dataset_id:
-    comment: DataCatalog Dataset ID for GLDAS
-    value: 5babae3f-c468-4e01-862e-8b201468e3b5
+  # DataCatalog Dataset ID for GLDAS
+  gldas_dataset_id: 5babae3f-c468-4e01-862e-8b201468e3b5
   agg_function:
     comment: Operation to be used for aggregation. Values can be ("sum", "average", "count")
     value: average

--- a/examples/aggregation/average_monthly_precipitation_rate.yml
+++ b/examples/aggregation/average_monthly_precipitation_rate.yml
@@ -1,9 +1,8 @@
 version: "1.0"
 description: Data transformation to aggregate monthly precipitation rate from original GLDAS data sources
 inputs:
-  gldas_dataset_id:
-    comment: DataCatalog Dataset ID for GLDAS
-    value: 5babae3f-c468-4e01-862e-8b201468e3b5
+  # DataCatalog Dataset ID for GLDAS
+  gldas_dataset_id: 5babae3f-c468-4e01-862e-8b201468e3b5
   agg_function:
     comment: Operation to be used for aggregation. Values can be ("sum", "average", "count")
     value: average

--- a/funcs/aggregations/variable_aggregation_func.py
+++ b/funcs/aggregations/variable_aggregation_func.py
@@ -128,6 +128,7 @@ class VariableAggregationFunc(IFunc):
                 }
                 dsmodel = DRepr.parse(dsmodel)
                 ds = outputs.ArrayBackend.from_drepr(dsmodel, resource_id)
+                ReaderContainer.get_instance().delete(resource_id)
         return {"data": ds}
 
     def validate(self) -> bool:


### PR DESCRIPTION
The new streaming pipeline system has the possibility of running into a
deadlock if not used correctly. With this update, we detect it and
stop the pipeline before it gets stuck indefinitely.

Added a shorthand for pipeline inputs in the config schema. In addition
to the standard way of defining pipeline inputs as a dictionary
{"comment": "Some comment", "value": "Any valid data type"}, you can
also simply specify the "value" directly if there is no comment. This
is applicable only for non-dictionary values. If the "value" is a
dictionary then it can only be used with the standard way. You can see the updated yml files in examples/aggregation for example